### PR TITLE
find additional bound states with the same JpiT

### DIFF
--- a/output_simplifier.py
+++ b/output_simplifier.py
@@ -302,6 +302,15 @@ def simplify(filename, verbose=False):
                 if verbose:
                     print('found first detail line')
                 step = "getting details"
+            elif bound_state_line(line):  # ``Bound state found at E_b=''
+                states.append(state_format.format(
+                    E=E, J=J, T=T, parity=parity, details="None"))
+                E_list.append(E)
+                state_titles.append("{}_{}_{}".format(J, parity, T))
+                E = get_e(line)
+                if verbose:
+                    print('Found bound state:', E)
+                step = "looking for details"  # details: i_p,p_chan,p_st
 
         # get all other detail lines
         elif step == "getting details":

--- a/output_simplifier.py
+++ b/output_simplifier.py
@@ -303,6 +303,8 @@ def simplify(filename, verbose=False):
                     print('found first detail line')
                 step = "getting details"
             elif bound_state_line(line):  # ``Bound state found at E_b=''
+                if verbose:
+                    print('found an additonal bound state before details, appending state')
                 states.append(state_format.format(
                     E=E, J=J, T=T, parity=parity, details="None"))
                 E_list.append(E)

--- a/output_simplifier.py
+++ b/output_simplifier.py
@@ -304,7 +304,7 @@ def simplify(filename, verbose=False):
                 step = "getting details"
             elif bound_state_line(line):  # ``Bound state found at E_b=''
                 if verbose:
-                    print('found an additonal bound state before details, appending state')
+                    print('found an additonal bound state, appending state')
                 states.append(state_format.format(
                     E=E, J=J, T=T, parity=parity, details="None"))
                 E_list.append(E)


### PR DESCRIPTION
Closes #2 
The `state_titles` returned from `simplify` now can contain duplicates (when multiple states have the same JpiT).

Example: 
`['0 1 0', '4 1 0', '4 1 0', '4 1 2', '8 1 0']`

The ncsm_rgm_...out_simplified now looks like this when there are multiple bound states:

    =========================================================================
    Bound State Energy = -12.558 MeV
    J = 2.0
    T = 0.0
    Parity = 1
    Details:
    None
    =========================================================================
    Bound State Energy = -0.3732 MeV
    J = 2.0
    T = 0.0
    Parity = 1
    Details:
    #  1   i_p,p_chan,p_st=  1  1  1   i_t,t_st=  1  1   2*s=  2    l=  1`

Perhaps a better/more general solution would be to attach the `details` section only to J, pi, T (and have multiple E values). The phase shift results are not connected to a specific E value.